### PR TITLE
Drop any live ServerConns first when dropping Server.

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -591,6 +591,17 @@ pub struct Server {
     conns: Slab<ServerConn>
 }
 
+impl Drop for Server {
+    fn drop(&mut self) {
+        // ServerConns rely on the cubeb context, so we must free them
+        // explicitly before the context is dropped.
+        if !self.conns.is_empty() {
+            debug!("dropping Server with {} live ServerConns", self.conns.len());
+            self.conns.clear();
+        }
+    }
+}
+
 impl Server {
     pub fn new(socket: UnixListener) -> Server {
         Server {


### PR DESCRIPTION
This should address BMO bug 1411849.