### PR TITLE
server: Don't warn! on EINTR, just return to the caller.

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -693,6 +693,7 @@ impl Server {
 
         match poll.poll(&mut events, None) {
             Ok(_) => {},
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => return Ok(()),
             Err(e) => warn!("server poll error: {}", e),
         }
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1409904#c8