### PR TITLE
Update to bincode 0.9

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -9,7 +9,7 @@ description = "Remote Cubeb IPC"
 
 [dependencies]
 cubeb = "0.4"
-bincode = "0.8"
+bincode = "0.9"
 bytes = "0.4"
 # rayon-core in Gecko uses futures 0.1.13
 futures = "=0.1.13"

--- a/audioipc/src/codec.rs
+++ b/audioipc/src/codec.rs
@@ -102,7 +102,7 @@ impl<In, Out> LengthDelimitedCodec<In, Out> {
 
         trace!("Attempting to decode");
         let msg = try!(deserialize::<Out>(buf.as_ref()).map_err(|e| match *e {
-            bincode::ErrorKind::IoError(e) => e,
+            bincode::ErrorKind::Io(e) => e,
             _ => io::Error::new(io::ErrorKind::Other, *e),
         }));
 
@@ -170,7 +170,7 @@ where
             serialize_into::<_, Self::In, _>(&mut buf.writer(), &item, Bounded(encoded_len))
         {
             match *e {
-                bincode::ErrorKind::IoError(e) => return Err(e),
+                bincode::ErrorKind::Io(e) => return Err(e),
                 _ => return Err(io::Error::new(io::ErrorKind::Other, *e)),
             }
         }


### PR DESCRIPTION
This matches the version used by webrender, so it reduces the amount of code in the Firefox build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/audioipc-2/32)
<!-- Reviewable:end -->
