### PR TITLE
Update cpupool version and add cpupool thread control.

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioipc-client"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
         "Matthew Gregan <kinetik@flim.org>",
         "Dan Glastonbury <dan.glastonbury@gmail.com>"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,7 +12,7 @@ audioipc = { path="../audioipc" }
 cubeb-backend = "0.4"
 foreign-types = "0.3"
 futures = { version="0.1.18", default-features=false, features=["use_std"] }
-futures-cpupool = { version="0.1.5", default-features=false }
+futures-cpupool = { version="0.1.8", default-features=false }
 libc = "0.2"
 log = "^0.3.6"
 tokio-core = "0.1"

--- a/client/src/context.rs
+++ b/client/src/context.rs
@@ -3,7 +3,7 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details
 
-use ClientStream;
+use {ClientStream, CPUPOOL_INIT_PARAMS, G_SERVER_FD};
 use assert_not_in_callback;
 use audioipc::{messages, ClientMessage, ServerMessage};
 use audioipc::{core, rpc};
@@ -69,7 +69,7 @@ impl ClientContext {
 // TODO: encapsulate connect, etc inside audioipc.
 fn open_server_stream() -> Result<net::UnixStream> {
     unsafe {
-        if let Some(fd) = super::G_SERVER_FD {
+        if let Some(fd) = G_SERVER_FD {
             return Ok(net::UnixStream::from_raw_fd(fd));
         }
 
@@ -113,9 +113,14 @@ impl ContextOps for ClientContext {
 
         let rpc = t!(rx_rpc.recv());
 
-        let cpupool = futures_cpupool::Builder::new()
-            .name_prefix("AudioIPC")
-            .create();
+        let cpupool = CPUPOOL_INIT_PARAMS.with(|p| {
+            let params = p.replace(None).unwrap();
+            futures_cpupool::Builder::new()
+                .name_prefix("AudioIPC")
+                .pool_size(params.pool_size)
+                .stack_size(params.stack_size)
+                .create()
+        });
 
         let ctx = Box::new(ClientContext {
             _ops: &CLIENT_OPS as *const _,
@@ -265,7 +270,7 @@ impl Drop for ClientContext {
         debug!("ClientContext drop...");
         let _ = send_recv!(self.rpc(), ClientDisconnect => ClientDisconnected);
         unsafe {
-            if super::G_SERVER_FD.is_some() {
+            if G_SERVER_FD.is_some() {
                 libc::close(super::G_SERVER_FD.take().unwrap());
             }
         }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -26,7 +26,33 @@ use std::os::raw::{c_char, c_int};
 use std::os::unix::io::RawFd;
 use stream::ClientStream;
 
+type InitParamsTls = std::cell::RefCell<Option<CpuPoolInitParams>>;
+
 thread_local!(static IN_CALLBACK: std::cell::RefCell<bool> = std::cell::RefCell::new(false));
+thread_local!(static CPUPOOL_INIT_PARAMS: InitParamsTls = std::cell::RefCell::new(None));
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct AudioIpcInitParams {
+    pub server_connection: c_int,
+    pub pool_size: usize,
+    pub stack_size: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CpuPoolInitParams {
+    pub pool_size: usize,
+    pub stack_size: usize,
+}
+
+impl CpuPoolInitParams {
+    pub fn init_with(params: &AudioIpcInitParams) -> Self {
+        CpuPoolInitParams {
+            pool_size: params.pool_size,
+            stack_size: params.stack_size,
+        }
+    }
+}
 
 fn set_in_callback(in_callback: bool) {
     IN_CALLBACK.with(|b| {
@@ -41,6 +67,15 @@ fn assert_not_in_callback() {
     });
 }
 
+fn set_cpupool_init_params<P>(params: P)
+where
+    P: Into<Option<CpuPoolInitParams>>,
+{
+    CPUPOOL_INIT_PARAMS.with(|p| {
+        *p.borrow_mut() = params.into();
+    });
+}
+
 static mut G_SERVER_FD: Option<RawFd> = None;
 
 #[no_mangle]
@@ -48,15 +83,24 @@ static mut G_SERVER_FD: Option<RawFd> = None;
 pub unsafe extern "C" fn audioipc_client_init(
     c: *mut *mut ffi::cubeb,
     context_name: *const c_char,
-    server_connection: c_int,
+    init_params: *const AudioIpcInitParams,
 ) -> c_int {
+    if init_params.is_null() {
+        return cubeb_backend::ffi::CUBEB_ERROR;
+    }
+
+    let init_params = &*init_params;
+
     // TODO: Windows portability (for fd).
     // TODO: Better way to pass extra parameters to Context impl.
     if G_SERVER_FD.is_some() {
         panic!("audioipc client's server connection already initialized.");
     }
-    if server_connection >= 0 {
-        G_SERVER_FD = Some(server_connection);
+    if init_params.server_connection >= 0 {
+        G_SERVER_FD = Some(init_params.server_connection);
     }
+
+    let cpupool_init_params = CpuPoolInitParams::init_with(&init_params);
+    set_cpupool_init_params(cpupool_init_params);
     capi::capi_init::<ClientContext>(c, context_name)
 }

--- a/ipctest/src/client.rs
+++ b/ipctest/src/client.rs
@@ -149,7 +149,14 @@ pub fn client_test(fd: c_int) -> Result<()> {
     // init function to get a raw cubeb pointer.
     let context_name = CString::new("AudioIPC").unwrap();
     let mut c: *mut ffi::cubeb = ptr::null_mut();
-    if unsafe { audioipc_client::audioipc_client_init(&mut c, context_name.as_ptr(), fd) } < 0 {
+    let init_params = audioipc_client::AudioIpcInitParams {
+        server_connection: fd,
+        pool_size: 1,
+        stack_size: 4 * 1024,
+    };
+    if unsafe { audioipc_client::audioipc_client_init(&mut c, context_name.as_ptr(), &init_params) }
+        < 0
+    {
         return Err("Failed to connect to remote cubeb server.".into());
     }
     let ctx = unsafe { cubeb::Context::from_ptr(c) };


### PR DESCRIPTION
Change audioipc_client_init to take extra params.

Added `pool_size` (thread count) and `stack_size` params to `server_connection` as parameters to initialize AudioIPC client.

* pool_size: Controls the number of threads created in the pool.
* stack_size: Controls the size of the stack allocated per thread in the pool.

Because `audioipc_context_init` is a thin wrapper on `cubeb_context_init` style init, the extra params are passed via a thread local global variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/audioipc-2/37)
<!-- Reviewable:end -->
