### PR TITLE
client: Add user_ptr field to ClientStream for cubeb_stream_user_ptr.

### DIFF
--- a/client/src/context.rs
+++ b/client/src/context.rs
@@ -42,6 +42,9 @@ macro_rules! t(
 
 pub const CLIENT_OPS: Ops = capi_new!(ClientContext, ClientStream);
 
+// ClientContext's layout *must* match cubeb.c's `struct cubeb` for the
+// common fields.
+#[repr(C)]
 pub struct ClientContext {
     _ops: *const Ops,
     rpc: rpc::ClientProxy<ServerMessage, ClientMessage>,

--- a/client/src/stream.rs
+++ b/client/src/stream.rs
@@ -40,11 +40,15 @@ impl Drop for Device {
     }
 }
 
+// ClientStream's layout *must* match cubeb.c's `struct cubeb_stream` for the
+// common fields.
+#[repr(C)]
 #[derive(Debug)]
 pub struct ClientStream<'ctx> {
     // This must be a reference to Context for cubeb, cubeb accesses
     // stream methods via stream->context->ops
     context: &'ctx ClientContext,
+    user_ptr: *mut c_void,
     token: usize,
 }
 
@@ -172,6 +176,7 @@ impl<'ctx> ClientStream<'ctx> {
 
         let stream = Box::into_raw(Box::new(ClientStream {
             context: ctx,
+            user_ptr: user_ptr,
             token: data.token,
         }));
         Ok(unsafe { Stream::from_ptr(stream as *mut _) })


### PR DESCRIPTION
Also mark ClientContext and ClientStream #[repr(C)] to ensure the field layout matches what the libcubeb C ABI expects.

Before this, we were likely leaking the StreamCallbacks because cubeb_stream_user_ptr would return whatever value was in ClientStream.tokens... although I'm not sure why this wasn't crashing in Gecko.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/audioipc-2/39)
<!-- Reviewable:end -->
