### PR TITLE
Ipctest crash

### DIFF
--- a/client/src/stream.rs
+++ b/client/src/stream.rs
@@ -273,5 +273,13 @@ pub fn init(
     state_callback: ffi::cubeb_state_callback,
     user_ptr: *mut c_void,
 ) -> Result<Stream> {
-    ClientStream::init(ctx, init_params, data_callback, state_callback, user_ptr)
+    let stm = try!(ClientStream::init(
+        ctx,
+        init_params,
+        data_callback,
+        state_callback,
+        user_ptr
+    ));
+    debug_assert_eq!(stm.user_ptr(), user_ptr);
+    Ok(stm)
 }


### PR DESCRIPTION
Make ipctest fail if forked client process crashes.
Add debug assert that self.user_ptr() matches the user_ptr passed to stream_init.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/audioipc-2/40)
<!-- Reviewable:end -->
