### PR TITLE
Avoid passing the shm ptr for stream directions that weren't configured.

### DIFF
--- a/ipctest/src/client.rs
+++ b/ipctest/src/client.rs
@@ -152,7 +152,7 @@ pub fn client_test(fd: c_int) -> Result<()> {
     let init_params = audioipc_client::AudioIpcInitParams {
         server_connection: fd,
         pool_size: 1,
-        stack_size: 4 * 1024,
+        stack_size: 64 * 1024,
     };
     if unsafe { audioipc_client::audioipc_client_init(&mut c, context_name.as_ptr(), &init_params) }
         < 0


### PR DESCRIPTION
This fixes issue #42.

I also had to bump the thread stack size in ipctest as it was failing to run on macOS, even before I made any changes to the code.  I've made it 64kB, but Gecko is actually using 256kB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/audioipc-2/44)
<!-- Reviewable:end -->
