### PR TITLE
Fixed a deprecation warning due to an API change in serializing integers

### DIFF
--- a/audioipc/src/codec.rs
+++ b/audioipc/src/codec.rs
@@ -164,7 +164,7 @@ where
 
         buf.reserve((encoded_len + 2) as usize);
 
-        buf.put_u16::<LittleEndian>(encoded_len as u16);
+        buf.put_u16_le(encoded_len as u16);
 
         if let Err(e) = bincode::config()
             .limit(encoded_len)


### PR DESCRIPTION
Resolves https://bugzilla.mozilla.org/show_bug.cgi?id=1498244

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/audioipc-2/51)
<!-- Reviewable:end -->
