### PR TITLE
Clean up reslicing of audio buffers in AudioIPC's server data callback.

### DIFF
--- a/audioipc/src/messages.rs
+++ b/audioipc/src/messages.rs
@@ -229,7 +229,9 @@ pub enum ClientMessage {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum CallbackReq {
-    Data(isize, usize),
+    Data { nframes: isize,
+           input_frame_size: usize,
+           output_frame_size: usize },
     State(ffi::cubeb_state),
 }
 

--- a/client/src/stream.rs
+++ b/client/src/stream.rs
@@ -69,11 +69,12 @@ impl rpc::Server for CallbackServer {
 
     fn process(&mut self, req: Self::Request) -> Self::Future {
         match req {
-            CallbackReq::Data(nframes, frame_size) => {
+            CallbackReq::Data { nframes, input_frame_size, output_frame_size } => {
                 trace!(
-                    "stream_thread: Data Callback: nframes={} frame_size={}",
+                    "stream_thread: Data Callback: nframes={} input_fs={} output_fs={}",
                     nframes,
-                    frame_size
+                    input_frame_size,
+                    output_frame_size,
                 );
 
                 // Clone values that need to be moved into the cpu pool thread.
@@ -92,14 +93,14 @@ impl rpc::Server for CallbackServer {
                     // TODO: This is proof-of-concept. Make it better.
                     let input_ptr: *const u8 = match input_shm {
                         Some(shm) => shm
-                            .get_slice(nframes as usize * frame_size)
+                            .get_slice(nframes as usize * input_frame_size)
                             .unwrap()
                             .as_ptr(),
                         None => ptr::null(),
                     };
                     let output_ptr: *mut u8 = match output_shm {
                         Some(ref mut shm) => shm
-                            .get_mut_slice(nframes as usize * frame_size)
+                            .get_mut_slice(nframes as usize * output_frame_size)
                             .unwrap()
                             .as_mut_ptr(),
                         None => ptr::null_mut(),


### PR DESCRIPTION
Rather than sizing the input and output buffer slices in bytes in the FFI wrapper and rewrapping the slice in data_callback based on the frame size, just create the buffer slice with the correct size in the FFI wrapper.

This also fixes a potential bug for input-only streams where we would pass the output frame size (0) and try to use it as the input frame size, causing input-only streams to fail to capture any data.

r? @ChunMinChang please

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/audioipc-2/53)
<!-- Reviewable:end -->
