### PR TITLE
Silence error_chain deprecation warnings to fix build on nightly compiler.

### DIFF
--- a/audioipc/src/lib.rs
+++ b/audioipc/src/lib.rs
@@ -33,6 +33,7 @@ mod async;
 mod cmsg;
 pub mod codec;
 pub mod core;
+#[allow(deprecated)]
 pub mod errors;
 pub mod fd_passing;
 pub mod frame;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -34,6 +34,7 @@ use tokio_uds::UnixStream;
 
 mod server;
 
+#[allow(deprecated)]
 pub mod errors {
     error_chain! {
         links {


### PR DESCRIPTION
Fixes [BMO 1524818](https://bugzilla.mozilla.org/show_bug.cgi?id=1524818).

r? @chunminchang please

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/audioipc-2/54)
<!-- Reviewable:end -->
