### PR TITLE
Fix cross-platform cmsghdr tests by generating valid cmsghdr in C.

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -26,3 +26,6 @@ tokio-uds = "0.1.7"
 [dependencies.error-chain]
 version = "0.11.0"
 default-features = false
+
+[build-dependencies]
+cc = "1.0"

--- a/audioipc/build.rs
+++ b/audioipc/build.rs
@@ -1,0 +1,7 @@
+extern crate cc;
+
+fn main() {
+    cc::Build::new()
+        .file("src/cmsghdr.c")
+        .compile("cmsghdr");
+}

--- a/audioipc/src/cmsghdr.c
+++ b/audioipc/src/cmsghdr.c
@@ -1,0 +1,23 @@
+#include <sys/socket.h>
+#include <inttypes.h>
+#include <string.h>
+
+const uint8_t*
+cmsghdr_bytes(size_t* size)
+{
+  int myfds[3] = {0, 1, 2};
+
+  static union {
+    uint8_t buf[CMSG_SPACE(sizeof(myfds))];
+    struct cmsghdr align;
+  } u;
+
+  u.align.cmsg_len = CMSG_LEN(sizeof(myfds));
+  u.align.cmsg_level = SOL_SOCKET;
+  u.align.cmsg_type = SCM_RIGHTS;
+
+  memcpy(CMSG_DATA(&u.align), myfds, sizeof(myfds));
+
+  *size = sizeof(u);
+  return (const uint8_t*)&u.buf;
+}


### PR DESCRIPTION
The static CMSG_BYTES assumes a particular layout for struct cmsghdr, but different platforms may have a different layout resulting in test failures.  Use some native C code to generate a platform-specific CMSG_BYTES equivalent for the tests.

r? @chunminchang

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/audioipc-2/55)
<!-- Reviewable:end -->
