### PR TITLE
Revert ClientContext::init error handling behaviour.

### DIFF
--- a/client/src/context.rs
+++ b/client/src/context.rs
@@ -136,7 +136,9 @@ impl ContextOps for ClientContext {
             .stack_size(params.stack_size)
             .create();
 
-        send_recv!(rpc, ClientConnect(std::process::id()) => ClientConnected)?;
+        // Don't let errors bubble from here.  Later calls against this context
+        // will return errors the caller expects to handle.
+        let _ = send_recv!(rpc, ClientConnect(std::process::id()) => ClientConnected);
 
         let ctx = Box::new(ClientContext {
             _ops: &CLIENT_OPS as *const _,


### PR DESCRIPTION
ClientContext::init would previously always succeed, even if later calls against the context would fail.  The addition of the ClientConnect message to ClientContext::init could cause an early error return without providing the caller with a valid context.

This is a simple fix for [BMO 1533539](https://bugzilla.mozilla.org/show_bug.cgi?id=1533539), suitable for uplifting to beta (67).  While investigating this I found several cleanups that I'd like to make to the error handling, but I'll leave them for a later bug to avoid complicating the beta (67) uplift patch.

r? @ChunMinChang please

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/audioipc-2/58)
<!-- Reviewable:end -->
