### PR TITLE
Fixes for #56, #57, and BMO #1536613

### DIFF
--- a/audioipc/build.rs
+++ b/audioipc/build.rs
@@ -1,7 +1,9 @@
 extern crate cc;
 
 fn main() {
-    cc::Build::new()
-        .file("src/cmsghdr.c")
-        .compile("cmsghdr");
+    if std::env::var_os("CARGO_CFG_UNIX").is_some() {
+        cc::Build::new()
+            .file("src/cmsghdr.c")
+            .compile("cmsghdr");
+    }
 }

--- a/audioipc/src/cmsg.rs
+++ b/audioipc/src/cmsg.rs
@@ -106,12 +106,16 @@ impl ControlMsgBuilder {
                 return Err(Error::NoSpace);
             }
 
+            // Some definitions of cmsghdr contain padding.  Rather
+            // than try to keep an up-to-date #cfg list to handle
+            // that, just use a pre-zeroed struct to fill out any
+            // fields we don't care about.
+            let zeroed = unsafe { mem::zeroed() };
             let cmsghdr = cmsghdr {
                 cmsg_len: cmsg_len as _,
-                #[cfg(target_env = "musl")]
-                __pad1: 0,
                 cmsg_level: level,
                 cmsg_type: kind,
+                ..zeroed
             };
 
             let cmsghdr = unsafe {

--- a/audioipc/src/messagestream_win.rs
+++ b/audioipc/src/messagestream_win.rs
@@ -5,7 +5,7 @@
 
 extern crate mio_named_pipes;
 use std::os::windows::io::{IntoRawHandle, FromRawHandle, AsRawHandle, RawHandle};
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_named_pipes;
 
@@ -100,7 +100,7 @@ impl IntoRawHandle for MessageStream {
     }
 }
 
-static PIPE_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+static PIPE_ID: AtomicUsize = AtomicUsize::new(0);
 
 fn get_pipe_name() -> String {
     let pid = std::process::id();


### PR DESCRIPTION
- Issue #56: Avoid warning when building with rustc >= 1.34.
- Issue #57: Don't build cmsghdr.c test on non-Unix.
- [BMO #1536613](https://bugzilla.mozilla.org/show_bug.cgi?id=1536613): Fix build failure on 32-bit MUSL targets.

r? @ChunMinChang please

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/audioipc-2/59)
<!-- Reviewable:end -->
