### PR TITLE
remove unnecessary `mut`

### DIFF
--- a/audioipc/src/fd_passing.rs
+++ b/audioipc/src/fd_passing.rs
@@ -100,7 +100,7 @@ where
                 Some(frame) => {
                     trace!("sending msg {:?}, fds {:?}", frame.msgs, frame.fds);
                     let mut msgs = frame.msgs.clone().into_buf();
-                    let mut fds = match frame.fds {
+                    let fds = match frame.fds {
                         Some(ref fds) => fds.clone(),
                         None => Bytes::new(),
                     }.into_buf();


### PR DESCRIPTION
Newer versions of Rust complain about this by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/djg/audioipc-2/61)
<!-- Reviewable:end -->
