### PR TITLE
Remove the code to start the audio callback threads early, and add a message to promote a thread to RT from the server process.

### DIFF
--- a/audioipc/src/messages.rs
+++ b/audioipc/src/messages.rs
@@ -9,6 +9,8 @@ use cubeb::{self, ffi};
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_uint};
 use std::ptr;
+#[cfg(target_os = "linux")]
+use audio_thread_priority::RtPriorityThreadInfo;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Device {
@@ -207,6 +209,9 @@ pub enum ServerMessage {
     StreamSetVolume(usize, f32),
     StreamGetCurrentDevice(usize),
     StreamRegisterDeviceChangeCallback(usize, bool),
+
+    #[cfg(target_os = "linux")]
+    PromoteThreadToRealTime([u8; std::mem::size_of::<RtPriorityThreadInfo>()]),
 }
 
 // Server -> Client messages.
@@ -235,6 +240,9 @@ pub enum ClientMessage {
     StreamVolumeSet,
     StreamCurrentDevice(Device),
     StreamRegisterDeviceChangeCallback,
+
+    #[cfg(target_os = "linux")]
+    ThreadPromoted,
 
     Error(c_int),
 }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,6 +14,5 @@ audioipc = { path="../audioipc" }
 cubeb-backend = "0.6.0"
 futures = { version="0.1.18", default-features=false, features=["use_std"] }
 futures-cpupool = { version="0.1.8", default-features=false }
-lazy_static = "1.2.0"
 log = "0.4"
 tokio = "0.1"

--- a/client/src/context.rs
+++ b/client/src/context.rs
@@ -6,9 +6,11 @@
 use crate::assert_not_in_callback;
 use crate::stream;
 #[cfg(target_os = "linux")]
-use crate::G_THREAD_POOL;
-use crate::{ClientStream, CpuPoolInitParams, CPUPOOL_INIT_PARAMS, G_SERVER_FD};
+use crate::{ClientStream, G_SERVER_FD, CPUPOOL_INIT_PARAMS};
+#[cfg(not(target_os = "linux"))]
 use audio_thread_priority::promote_current_thread_to_real_time;
+#[cfg(target_os = "linux")]
+use audio_thread_priority::get_current_thread_info;
 use audioipc::codec::LengthDelimitedCodec;
 use audioipc::frame::{framed, Framed};
 use audioipc::platformhandle_passing::{framed_with_platformhandles, FramedWithPlatformHandles};
@@ -90,7 +92,30 @@ fn open_server_stream() -> io::Result<audioipc::MessageStream> {
     }
 }
 
-fn register_thread(callback: Option<extern "C" fn(*const ::std::os::raw::c_char)>) {
+#[cfg(target_os = "linux")]
+fn promote_thread(rpc: &rpc::ClientProxy<ServerMessage, ClientMessage>)
+{
+    match get_current_thread_info() {
+        Ok(info) => {
+            let bytes = info.serialize();
+            match send_recv!(rpc, PromoteThreadToRealTime(bytes) => ThreadPromoted) {
+                Ok(_) => {
+                    info!("Audio thread promoted to real-time.");
+                }
+                Err(_) => {
+                    warn!("Could not promote thread to real-time.");
+                }
+            };
+        }
+        Err(_) => {
+            warn!("Could not remotely promote thread to RT.");
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn promote_thread()
+{
     match promote_current_thread_to_real_time(0, 48000) {
         Ok(_) => {
             info!("Audio thread promoted to real-time.");
@@ -99,6 +124,9 @@ fn register_thread(callback: Option<extern "C" fn(*const ::std::os::raw::c_char)
             warn!("Could not promote thread to real-time.");
         }
     }
+}
+
+fn register_thread(callback: Option<extern "C" fn(*const ::std::os::raw::c_char)>) {
     if let Some(func) = callback {
         let thr = thread::current();
         let name = CString::new(thr.name().unwrap()).unwrap();
@@ -106,30 +134,10 @@ fn register_thread(callback: Option<extern "C" fn(*const ::std::os::raw::c_char)
     }
 }
 
-fn create_thread_pool(init_params: CpuPoolInitParams) -> CpuPool {
-    futures_cpupool::Builder::new()
-        .name_prefix("AudioIPC")
-        .after_start(move || register_thread(init_params.thread_create_callback))
-        .pool_size(init_params.pool_size)
-        .stack_size(init_params.stack_size)
-        .create()
-}
-
-#[cfg(target_os = "linux")]
-fn get_thread_pool(init_params: CpuPoolInitParams) -> CpuPool {
-    let mut guard = G_THREAD_POOL.lock().unwrap();
-    if guard.is_some() {
-        // Sandbox is on, and the thread pool was created earlier, before the lockdown.
-        guard.take().unwrap()
-    } else {
-        // Sandbox is off, let's create the pool now, promoting the threads will work.
-        create_thread_pool(init_params)
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-fn get_thread_pool(init_params: CpuPoolInitParams) -> CpuPool {
-    create_thread_pool(init_params)
+fn promote_and_register_thread(rpc: &rpc::ClientProxy<ServerMessage, ClientMessage>,
+    callback: Option<extern "C" fn(*const ::std::os::raw::c_char)>) {
+    promote_thread(rpc);
+    register_thread(callback);
 }
 
 #[derive(Default)]
@@ -219,6 +227,7 @@ impl ContextOps for ClientContext {
         .map_err(|_| Error::default())?;
 
         let rpc = rx_rpc.recv().map_err(|_| Error::default())?;
+        let rpc2 = rpc.clone();
 
         // Don't let errors bubble from here.  Later calls against this context
         // will return errors the caller expects to handle.
@@ -228,7 +237,12 @@ impl ContextOps for ClientContext {
             .unwrap_or_else(|_| "(remote error)".to_string());
         let backend_id = CString::new(backend_id).expect("backend_id query failed");
 
-        let cpu_pool = get_thread_pool(params);
+        let cpu_pool = futures_cpupool::Builder::new()
+            .name_prefix("AudioIPC")
+            .after_start(move || promote_and_register_thread(&rpc2, params.thread_create_callback))
+            .pool_size(params.pool_size)
+            .stack_size(params.stack_size)
+            .create();
 
         let ctx = Box::new(ClientContext {
             _ops: &CLIENT_OPS as *const _,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -8,8 +8,6 @@
 extern crate cubeb_backend;
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate lazy_static;
 
 #[macro_use]
 mod send_recv;
@@ -19,29 +17,14 @@ mod stream;
 use crate::context::ClientContext;
 use crate::stream::ClientStream;
 #[cfg(target_os = "linux")]
-use audio_thread_priority::promote_current_thread_to_real_time;
-use audio_thread_priority::RtPriorityHandle;
 use audioipc::{PlatformHandle, PlatformHandleType};
 use cubeb_backend::{capi, ffi};
-use futures_cpupool::CpuPool;
-#[cfg(target_os = "linux")]
-use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
-use std::sync::Mutex;
-#[cfg(target_os = "linux")]
-use std::sync::{Arc, Condvar};
-#[cfg(target_os = "linux")]
-use std::thread;
 
 type InitParamsTls = std::cell::RefCell<Option<CpuPoolInitParams>>;
 
 thread_local!(static IN_CALLBACK: std::cell::RefCell<bool> = std::cell::RefCell::new(false));
 thread_local!(static CPUPOOL_INIT_PARAMS: InitParamsTls = std::cell::RefCell::new(None));
-thread_local!(static G_PRIORITY_HANDLES: std::cell::RefCell<Vec<RtPriorityHandle>> = std::cell::RefCell::new(vec![]));
-
-lazy_static! {
-    static ref G_THREAD_POOL: Mutex<Option<CpuPool>> = Mutex::new(None);
-}
 
 // This must match the definition of AudioIpcInitParams in
 // dom/media/CubebUtils.cpp in Gecko.
@@ -95,63 +78,6 @@ where
 }
 
 static mut G_SERVER_FD: Option<PlatformHandle> = None;
-
-#[cfg(target_os = "linux")]
-#[no_mangle]
-pub unsafe extern "C" fn audioipc_init_threads(init_params: *const AudioIpcInitParams) {
-    let thread_create_callback = (*init_params).thread_create_callback;
-
-    // It is critical that this function waits until the various threads are created, promoted to
-    // real-time, and _then_ return, because the sandbox lockdown happens right after returning
-    // from here.
-    let pair = Arc::new((Mutex::new((*init_params).pool_size), Condvar::new()));
-    let pair2 = pair.clone();
-
-    let register_thread = move || {
-        if let Some(func) = thread_create_callback {
-            match promote_current_thread_to_real_time(0, 48000) {
-                Ok(handle) => {
-                    G_PRIORITY_HANDLES.with(|handles| {
-                        (handles.borrow_mut()).push(handle);
-                    });
-                }
-                Err(_) => {
-                    warn!("Could not promote audio threads to real-time during initialization.");
-                }
-            }
-            let thr = thread::current();
-            let name = CString::new(thr.name().unwrap()).unwrap();
-            func(name.as_ptr());
-            let &(ref lock, ref cvar) = &*pair2;
-            let mut count = lock.lock().unwrap();
-            *count -= 1;
-            cvar.notify_one();
-        }
-    };
-
-    let mut pool = G_THREAD_POOL.lock().unwrap();
-
-    *pool = Some(
-        futures_cpupool::Builder::new()
-            .name_prefix("AudioIPC")
-            .after_start(register_thread)
-            .pool_size((*init_params).pool_size)
-            .stack_size((*init_params).stack_size)
-            .create(),
-    );
-
-    let &(ref lock, ref cvar) = &*pair;
-    let mut count = lock.lock().unwrap();
-    while *count != 0 {
-        count = cvar.wait(count).unwrap();
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-#[no_mangle]
-pub unsafe extern "C" fn audioipc_init_threads(_: *const AudioIpcInitParams) {
-    unimplemented!();
-}
 
 #[no_mangle]
 /// Entry point from C code.


### PR DESCRIPTION
With `audio_thread_priority` version `0.20` it's possible to promote a
thread to real-time from another process. This allows removing the
workaround that was previously done to create the threads early before
the sandbox lockdown.

Additionaly, this patch adds a new message that allows passing a
`RtPriorityThreadInfo` struct via IPC, so that the server can promote
a client thread in a sandboxed process.

This is part of [BMO#1575883](https://bugzilla.mozilla.org/show_bug.cgi?id=1575883).