### PR TITLE
Gecko re-sync: use the right `audio_thread_priority` version

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -19,6 +19,7 @@ serde = "1.*.*"
 serde_derive = "1.*.*"
 tokio = "0.1"
 tokio-io = "0.1"
+audio_thread_priority = "0.20.2"
 
 [target.'cfg(unix)'.dependencies]
 iovec = "0.1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,7 +9,7 @@ description = "Cubeb Backend for talking to remote cubeb server."
 edition = "2018"
 
 [dependencies]
-audio_thread_priority = "0.18.0"
+audio_thread_priority = "0.20.2"
 audioipc = { path="../audioipc" }
 cubeb-backend = "0.6.0"
 futures = { version="0.1.18", default-features=false, features=["use_std"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,7 +9,7 @@ description = "Remote cubeb server"
 edition = "2018"
 
 [dependencies]
-audio_thread_priority = "0.18.0"
+audio_thread_priority = "0.20.2"
 audioipc = { path = "../audioipc" }
 cubeb-core = "0.6.0"
 futures = "0.1.18"


### PR DESCRIPTION
0.20.2 just got published with a fix for musl.