### PR TITLE
Use audio_thread_priority version 0.21 to fix a compilation issue on Linux when using musl

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.*.*"
 serde_derive = "1.*.*"
 tokio = "0.1"
 tokio-io = "0.1"
-audio_thread_priority = "0.20.2"
+audio_thread_priority = "0.21"
 
 [target.'cfg(unix)'.dependencies]
 iovec = "0.1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,7 +9,7 @@ description = "Cubeb Backend for talking to remote cubeb server."
 edition = "2018"
 
 [dependencies]
-audio_thread_priority = "0.20.2"
+audio_thread_priority = "0.21"
 audioipc = { path="../audioipc" }
 cubeb-backend = "0.6.0"
 futures = { version="0.1.18", default-features=false, features=["use_std"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,7 +9,7 @@ description = "Remote cubeb server"
 edition = "2018"
 
 [dependencies]
-audio_thread_priority = "0.20.2"
+audio_thread_priority = "0.21"
 audioipc = { path = "../audioipc" }
 cubeb-core = "0.6.0"
 futures = "0.1.18"


### PR DESCRIPTION
This fixes https://github.com/djg/audioipc-2/issues/80.