### PR TITLE
Windows pipe fixes

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -29,9 +29,9 @@ mio-uds = "0.6.7"
 tokio-reactor = "0.1"
 
 [target.'cfg(windows)'.dependencies]
+mio = "0.6.19"
 miow = "0.3.3"
 mio-named-pipes = { git = "https://github.com/alexcrichton/mio-named-pipes" }
-tokio-named-pipes = { git = "https://github.com/NikVolf/tokio-named-pipes", branch = "stable" }
 winapi = { version = "0.3.6", features = ["combaseapi", "objbase"] }
 
 [dependencies.error-chain]

--- a/audioipc/src/lib.rs
+++ b/audioipc/src/lib.rs
@@ -41,6 +41,9 @@ pub mod shm;
 #[cfg(unix)]
 mod tokio_uds_stream;
 
+#[cfg(windows)]
+mod tokio_named_pipes;
+
 pub use crate::messages::{ClientMessage, ServerMessage};
 use std::env::temp_dir;
 use std::path::PathBuf;

--- a/audioipc/src/messagestream_unix.rs
+++ b/audioipc/src/messagestream_unix.rs
@@ -39,6 +39,12 @@ impl MessageStream {
     }
 }
 
+impl IntoRawFd for MessageStream {
+    fn into_raw_fd(self) -> RawFd {
+        self.0.into_raw_fd()
+    }
+}
+
 impl AsyncMessageStream {
     fn new(stream: tokio_uds::UnixStream) -> AsyncMessageStream {
         AsyncMessageStream(stream)
@@ -95,11 +101,5 @@ impl AsyncWrite for AsyncMessageStream {
 impl AsRawFd for AsyncMessageStream {
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
-    }
-}
-
-impl IntoRawFd for MessageStream {
-    fn into_raw_fd(self) -> RawFd {
-        self.0.into_raw_fd()
     }
 }

--- a/audioipc/src/messagestream_win.rs
+++ b/audioipc/src/messagestream_win.rs
@@ -8,7 +8,7 @@ use std::os::windows::fs::*;
 use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio_io::{AsyncRead, AsyncWrite};
-use tokio_named_pipes;
+use super::tokio_named_pipes;
 use winapi::um::winbase::FILE_FLAG_OVERLAPPED;
 
 #[derive(Debug)]

--- a/audioipc/src/messagestream_win.rs
+++ b/audioipc/src/messagestream_win.rs
@@ -23,8 +23,8 @@ impl MessageStream {
     pub fn anonymous_ipc_pair(
     ) -> std::result::Result<(MessageStream, MessageStream), std::io::Error> {
         let pipe_name = get_pipe_name();
-        let pipe1 = miow::pipe::NamedPipe::new(&pipe_name)?;
-        let pipe2 = {
+        let pipe_server = miow::pipe::NamedPipe::new(&pipe_name)?;
+        let pipe_client = {
             let mut opts = std::fs::OpenOptions::new();
             opts.read(true)
                 .write(true)
@@ -32,7 +32,7 @@ impl MessageStream {
             let file = opts.open(&pipe_name)?;
             unsafe { miow::pipe::NamedPipe::from_raw_handle(file.into_raw_handle()) }
         };
-        Ok((MessageStream::new(pipe1), MessageStream::new(pipe2)))
+        Ok((MessageStream::new(pipe_server), MessageStream::new(pipe_client)))
     }
 
     pub unsafe fn from_raw_fd(raw: super::PlatformHandleType) -> MessageStream {
@@ -47,6 +47,12 @@ impl MessageStream {
         Ok(AsyncMessageStream::new(
             tokio_named_pipes::NamedPipe::from_pipe(pipe, handle)?,
         ))
+    }
+}
+
+impl IntoRawHandle for MessageStream {
+    fn into_raw_handle(self) -> RawHandle {
+        self.0.into_raw_handle()
     }
 }
 
@@ -90,12 +96,6 @@ impl AsyncWrite for AsyncMessageStream {
 impl AsRawHandle for AsyncMessageStream {
     fn as_raw_handle(&self) -> RawHandle {
         self.0.as_raw_handle()
-    }
-}
-
-impl IntoRawHandle for MessageStream {
-    fn into_raw_handle(self) -> RawHandle {
-        self.0.into_raw_handle()
     }
 }
 

--- a/audioipc/src/rpc/client/mod.rs
+++ b/audioipc/src/rpc/client/mod.rs
@@ -156,6 +156,7 @@ where
 
 impl<C: Client> Drop for ClientHandler<C> {
     fn drop(&mut self) {
+        let _ = self.transport.close();
         self.in_flight.clear();
     }
 }

--- a/audioipc/src/rpc/server.rs
+++ b/audioipc/src/rpc/server.rs
@@ -157,6 +157,7 @@ where
 
 impl<S: Server> Drop for ServerHandler<S> {
     fn drop(&mut self) {
+        let _ = self.transport.close();
         self.in_flight.clear();
     }
 }

--- a/audioipc/src/tokio_named_pipes.rs
+++ b/audioipc/src/tokio_named_pipes.rs
@@ -1,0 +1,154 @@
+#![cfg(windows)]
+
+extern crate tokio;
+extern crate bytes;
+extern crate mio;
+extern crate mio_named_pipes;
+extern crate futures;
+
+use std::ffi::OsStr;
+use std::fmt;
+use std::io::{Read, Write};
+use std::os::windows::io::*;
+
+use futures::{Async, Poll};
+use bytes::{BufMut, Buf};
+use mio::Ready;
+use tokio::reactor::{Handle, PollEvented2};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+pub struct NamedPipe {
+    io: PollEvented2<mio_named_pipes::NamedPipe>,
+}
+
+impl NamedPipe {
+    pub fn new<P: AsRef<OsStr>>(p: P, handle: &Handle) -> std::io::Result<NamedPipe> {
+        NamedPipe::_new(p.as_ref(), handle)
+    }
+
+    fn _new(p: &OsStr, handle: &Handle) -> std::io::Result<NamedPipe> {
+        let inner = try!(mio_named_pipes::NamedPipe::new(p));
+        NamedPipe::from_pipe(inner, handle)
+    }
+
+    pub fn from_pipe(pipe: mio_named_pipes::NamedPipe, handle: &Handle)
+            -> std::io::Result<NamedPipe> {
+        Ok(NamedPipe {
+            io: PollEvented2::new_with_handle(pipe, handle)?,
+        })
+    }
+
+    pub fn connect(&self) -> std::io::Result<()> {
+        self.io.get_ref().connect()
+    }
+
+    pub fn disconnect(&self) -> std::io::Result<()> {
+        self.io.get_ref().disconnect()
+    }
+
+    pub fn poll_read_ready_readable(&mut self) -> tokio::io::Result<Async<Ready>> {
+        self.io.poll_read_ready(Ready::readable())
+    }
+
+    pub fn poll_write_ready(&mut self) -> tokio::io::Result<Async<Ready>> {
+        self.io.poll_write_ready()
+    }
+
+    fn io_mut(&mut self) -> &mut PollEvented2<mio_named_pipes::NamedPipe> {
+        &mut self.io
+    }
+}
+
+impl Read for NamedPipe {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.io.read(buf)
+    }
+}
+
+impl Write for NamedPipe {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.io.write(buf)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.io.flush()
+    }
+}
+
+impl<'a> Read for &'a NamedPipe {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        (&self.io).read(buf)
+    }
+}
+
+impl<'a> Write for &'a NamedPipe {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        (&self.io).write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        (&self.io).flush()
+    }
+}
+
+impl AsyncRead for NamedPipe {
+    unsafe fn prepare_uninitialized_buffer(&self, _: &mut [u8]) -> bool {
+        false
+    }
+
+    fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Poll<usize, std::io::Error> {
+        if let Async::NotReady = self.io.poll_read_ready(Ready::readable())? {
+            return Ok(Async::NotReady)
+        }
+
+        let mut stack_buf = [0u8; 1024];
+        let bytes_read = self.io_mut().read(&mut stack_buf);
+        match bytes_read {
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => { 
+                self.io_mut().clear_read_ready(Ready::readable())?;
+                return Ok(Async::NotReady);
+            },
+            Err(e) => Err(e),
+            Ok(bytes_read) => {
+                buf.put_slice(&stack_buf[0..bytes_read]);
+                Ok(Async::Ready(bytes_read))
+            }
+        }
+    }
+}
+
+impl AsyncWrite for NamedPipe {
+    fn shutdown(&mut self) -> Poll<(), std::io::Error> {
+         Ok(().into())
+    }
+
+    fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, std::io::Error> {
+        if let Async::NotReady = self.io.poll_write_ready()? {
+            return Ok(Async::NotReady)
+        }
+
+        let bytes_wrt = self.io_mut().write(buf.bytes());
+        match bytes_wrt {
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => { 
+                self.io_mut().clear_write_ready()?;
+                return Ok(Async::NotReady);
+            },
+            Err(e) => Err(e),
+            Ok(bytes_wrt) => {
+                buf.advance(bytes_wrt);
+                Ok(Async::Ready(bytes_wrt))
+            }
+        }
+    }
+}
+
+impl fmt::Debug for NamedPipe {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.io.get_ref().fmt(f)
+    }
+}
+
+impl AsRawHandle for NamedPipe {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.io.get_ref().as_raw_handle()
+    }
+}

--- a/audioipc/src/tokio_named_pipes.rs
+++ b/audioipc/src/tokio_named_pipes.rs
@@ -1,10 +1,8 @@
-#![cfg(windows)]
+// Copied from tokio-named-pipes/src/lib.rs revision 49ec1ba8bbc94ab6fc9636af2a00dfb3204080c8 (tokio-named-pipes 0.2.0)
+// This file is dual licensed under the MIT and Apache-2.0 per upstream: https://github.com/NikVolf/tokio-named-pipes/blob/stable/LICENSE-MIT and https://github.com/NikVolf/tokio-named-pipes/blob/stable/LICENSE-APACHE
+// - Implement AsyncWrite::shutdown
 
-extern crate tokio;
-extern crate bytes;
-extern crate mio;
-extern crate mio_named_pipes;
-extern crate futures;
+#![cfg(windows)]
 
 use std::ffi::OsStr;
 use std::fmt;
@@ -27,7 +25,7 @@ impl NamedPipe {
     }
 
     fn _new(p: &OsStr, handle: &Handle) -> std::io::Result<NamedPipe> {
-        let inner = try!(mio_named_pipes::NamedPipe::new(p));
+        let inner = mio_named_pipes::NamedPipe::new(p)?;
         NamedPipe::from_pipe(inner, handle)
     }
 
@@ -103,7 +101,7 @@ impl AsyncRead for NamedPipe {
         let mut stack_buf = [0u8; 1024];
         let bytes_read = self.io_mut().read(&mut stack_buf);
         match bytes_read {
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => { 
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 self.io_mut().clear_read_ready(Ready::readable())?;
                 return Ok(Async::NotReady);
             },
@@ -118,7 +116,8 @@ impl AsyncRead for NamedPipe {
 
 impl AsyncWrite for NamedPipe {
     fn shutdown(&mut self) -> Poll<(), std::io::Error> {
-         Ok(().into())
+        let _ = self.disconnect();
+        Ok(().into())
     }
 
     fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, std::io::Error> {
@@ -128,7 +127,7 @@ impl AsyncWrite for NamedPipe {
 
         let bytes_wrt = self.io_mut().write(buf.bytes());
         match bytes_wrt {
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => { 
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 self.io_mut().clear_write_ready()?;
                 return Ok(Async::NotReady);
             },

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -124,7 +124,7 @@ pub extern "C" fn audioipc_server_new_client(p: *mut c_void) -> PlatformHandleTy
     // is registered with the reactor core, the other side is returned
     // to the caller.
     MessageStream::anonymous_ipc_pair()
-        .and_then(|(sock1, sock2)| {
+        .and_then(|(ipc_server, ipc_client)| {
             // Spawn closure to run on same thread as reactor::Core
             // via remote handle.
             wrapper
@@ -133,20 +133,20 @@ pub extern "C" fn audioipc_server_new_client(p: *mut c_void) -> PlatformHandleTy
                 .spawn(futures::future::lazy(|| {
                     trace!("Incoming connection");
                     let handle = reactor::Handle::default();
-                    sock2.into_tokio_ipc(&handle)
+                    ipc_server.into_tokio_ipc(&handle)
                     .and_then(|sock| {
                         let transport = framed_with_platformhandles(sock, Default::default());
                         rpc::bind_server(transport, server::CubebServer::new(core_handle));
                         Ok(())
                     }).map_err(|_| ())
-                    // Notify waiting thread that sock2 has been registered.
+                    // Notify waiting thread that server has been registered.
                     .and_then(|_| wait_tx.send(()))
                 }))
                 .expect("Failed to spawn CubebServer");
-            // Wait for notification that sock2 has been registered
+            // Wait for notification that server has been registered
             // with reactor::Core.
             let _ = wait_rx.wait();
-            Ok(unsafe { PlatformHandle::from(sock1).into_raw() })
+            Ok(unsafe { PlatformHandle::from(ipc_client).into_raw() })
         })
         .unwrap_or(audioipc::INVALID_HANDLE_VALUE)
 }


### PR DESCRIPTION
This is the same changes included in BMO 1590249:
- Fix tokio_named_pipes::NamedPipe shutdown
- Shutdown ClientHandler and ServerHandler correctly on drop
- Clarify server/client pipe ends and use appropriate end in appropriate location

r? @ChunMinChang please