### PR TITLE
audioipc: Add thread_destroy_callback for unregistering profiler.

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -33,6 +33,7 @@ pub struct AudioIpcInitParams {
     pub pool_size: usize,
     pub stack_size: usize,
     pub thread_create_callback: Option<extern "C" fn(*const ::std::os::raw::c_char)>,
+    pub thread_destroy_callback: Option<extern "C" fn()>,
 }
 
 unsafe impl Send for AudioIpcInitParams {}

--- a/ipctest/src/client.rs
+++ b/ipctest/src/client.rs
@@ -158,6 +158,7 @@ pub fn client_test(fd: audioipc::PlatformHandleType) -> Result<()> {
         pool_size: 1,
         stack_size: 64 * 1024,
         thread_create_callback: None,
+        thread_destroy_callback: None,
     };
     if unsafe { audioipc_client::audioipc_client_init(&mut c, context_name.as_ptr(), &init_params) }
         < 0

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -71,7 +71,7 @@ fn run() -> Result<ServerWrapper> {
         }
         trace!("Starting up cubeb audio callback event loop thread...");
         Ok(())
-    })
+    }, || {})
     .or_else(|e| {
         debug!(
             "Failed to start cubeb audio callback event loop thread: {:?}",
@@ -80,7 +80,7 @@ fn run() -> Result<ServerWrapper> {
         Err(e)
     })?;
 
-    let core_thread = core::spawn_thread("AudioIPC Server RPC", move || Ok(())).or_else(|e| {
+    let core_thread = core::spawn_thread("AudioIPC Server RPC", move || Ok(()), || {}).or_else(|e| {
         debug!(
             "Failed to cubeb audio core event loop thread: {:?}",
             e.description()


### PR DESCRIPTION
`thread_create_callback` is used to register AudioIPC threads with Gecko's profiler.  Per [BMO 1614547](https://bugzilla.mozilla.org/show_bug.cgi?id=1614547) and related bugs, we also need to ensure threads unregister when destroyed.  This adds `thread_destroy_callback` and arranges for it to be called in the appropriate places.

r? @ChunMinChang please