### PR TITLE
audioipc: Preallocate shm area before mapping to avoid late faults.

### DIFF
--- a/audioipc/src/lib.rs
+++ b/audioipc/src/lib.rs
@@ -45,8 +45,6 @@ mod tokio_uds_stream;
 mod tokio_named_pipes;
 
 pub use crate::messages::{ClientMessage, ServerMessage};
-use std::env::temp_dir;
-use std::path::PathBuf;
 
 // TODO: Remove hardcoded size and allow allocation based on cubeb backend requirements.
 pub const SHM_AREA_SIZE: usize = 2 * 1024 * 1024;
@@ -186,22 +184,6 @@ unsafe fn close_platformhandle(handle: PlatformHandleType) {
 #[cfg(windows)]
 unsafe fn close_platformhandle(handle: PlatformHandleType) {
     winapi::um::handleapi::CloseHandle(handle);
-}
-
-use std::sync::atomic::{AtomicUsize, Ordering};
-
-static SHM_ID: AtomicUsize = AtomicUsize::new(0);
-
-// Generate a temporary shm_path that is unique to the process.  This
-// path is used temporarily to create a shm segment, which is then
-// immediately deleted from the filesystem while retaining handles to
-// the shm to be shared between the server and client.
-pub fn get_shm_path() -> PathBuf {
-    let pid = std::process::id();
-    let shm_id = SHM_ID.fetch_add(1, Ordering::SeqCst);
-    let mut temp = temp_dir();
-    temp.push(&format!("cubeb-shm-{}-{}", pid, shm_id));
-    temp
 }
 
 #[cfg(unix)]

--- a/audioipc/src/shm.rs
+++ b/audioipc/src/shm.rs
@@ -7,22 +7,96 @@ use crate::errors::*;
 use memmap::{Mmap, MmapMut, MmapOptions};
 use std::cell::UnsafeCell;
 use std::fs::{remove_file, File, OpenOptions};
-use std::path::Path;
+use std::path::PathBuf;
 use std::sync::{atomic, Arc};
+use std::convert::TryInto;
+use std::env::temp_dir;
+
+fn open_shm_file(id: &str) -> Result<File> {
+    if cfg!(target_os = "linux") {
+        let mut path = PathBuf::from("/dev/shm");
+        path.push(id);
+
+        if let Ok(file) = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path) {
+                let _ = remove_file(&path);
+                return Ok(file);
+            }
+    };
+
+    let mut path = temp_dir();
+    path.push(id);
+
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(&path)?;
+
+    let _ = remove_file(&path);
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn allocate_file(file: &File, size: usize) -> Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    // Try Linux-specific fallocate.
+    #[cfg(target_os = "linux")]
+    unsafe {
+        if libc::fallocate(file.as_raw_fd(), 0, 0, size.try_into().unwrap()) == 0 {
+            return Ok(())
+        }
+    }
+
+    // Try macOS-specific fcntl.
+    #[cfg(target_os = "macos")]
+    unsafe {
+        let params = libc::fstore_t {
+            fst_flags: libc::F_ALLOCATEALL,
+            fst_posmode: libc::F_PEOFPOSMODE,
+            fst_offset: 0,
+            fst_length: size.try_into().unwrap(),
+            fst_bytesalloc: 0,
+        };
+        let r = libc::fcntl(file.as_raw_fd(), libc::F_PREALLOCATE, &params);
+        if r == 0 {
+            // F_PREALLOCATE doesn't update the file's size, so set now.
+            file.set_len(size.try_into().unwrap())?;
+            return Ok(());
+        }
+    }
+
+    // Fall back to portable version.
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly"))]
+    unsafe {
+        if libc::posix_fallocate(file.as_raw_fd(), 0, size.try_into().unwrap()) == 0 {
+            return Ok(())
+        }
+    }
+
+    // Last resort, stdlib calls ftruncate64 via set_len.
+    file.set_len(size.try_into().unwrap())?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn allocate_file(file: &File, size: usize) -> Result<()> {
+    file.set_len(size.try_into().unwrap())?;
+    Ok(())
+}
 
 pub struct SharedMemReader {
     mmap: Mmap,
 }
 
 impl SharedMemReader {
-    pub fn new(path: &Path, size: usize) -> Result<(SharedMemReader, File)> {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create_new(true)
-            .open(path)?;
-        let _ = remove_file(path);
-        file.set_len(size as u64)?;
+    pub fn new(id: &str, size: usize) -> Result<(SharedMemReader, File)> {
+        let file = open_shm_file(id)?;
+        allocate_file(&file, size)?;
         let mmap = unsafe { MmapOptions::new().map(&file)? };
         assert_eq!(mmap.len(), size);
         Ok((SharedMemReader { mmap }, file))
@@ -88,15 +162,11 @@ pub struct SharedMemWriter {
 }
 
 impl SharedMemWriter {
-    pub fn new(path: &Path, size: usize) -> Result<(SharedMemWriter, File)> {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create_new(true)
-            .open(path)?;
-        let _ = remove_file(path);
-        file.set_len(size as u64)?;
+    pub fn new(id: &str, size: usize) -> Result<(SharedMemWriter, File)> {
+        let file = open_shm_file(id)?;
+        allocate_file(&file, size)?;
         let mmap = unsafe { MmapOptions::new().map_mut(&file)? };
+        assert_eq!(mmap.len(), size);
         Ok((SharedMemWriter { mmap }, file))
     }
 


### PR DESCRIPTION
The existing code attempts to preallocate the shm area with
File::set_len, but that approach doesn't work on filesystems that
allow sparse files.  Accessing a mapped page in a shm area where the
backing file is lazily allocated can fault with SIGBUS (on Unix-like
platforms) due to low disk space.  To avoid this difficult to handle
failure mode, preallocate the entire shm area using OS-specific
techniques before mapping.

This change also also reworks the shm API slightly to take a path
fragment rather than a complete path.  This allows the shm code to try
creating the shm via preferential paths (e.g. /dev/shm on Linux)
before falling back to safe defaults.

r? @ChunMinChang please