### PR TITLE
Avoid using the pointer of a temporary variable

### DIFF
--- a/audioipc/src/shm.rs
+++ b/audioipc/src/shm.rs
@@ -14,9 +14,10 @@ use std::env::temp_dir;
 fn open_shm_file(id: &str) -> Result<File> {
     #[cfg(target_os = "linux")]
     {
+        let id_cstring = std::ffi::CString::new(id).unwrap();
         unsafe {
             let r = libc::syscall(libc::SYS_memfd_create,
-                                  std::ffi::CString::new(id).unwrap().as_ptr(),
+                                  id_cstring.as_ptr(),
                                   0);
             if r >= 0 {
                 use std::os::unix::io::FromRawFd as _;


### PR DESCRIPTION
The `std::ffi::CString::new(id).unwrap()` will create a temporary
variable. `std::ffi::CString::new(id).unwrap().as_ptr()` is a pointer
pointing to a temporary variable. Using this pointer directly is unsafe
since we cannot make sure the variable is alive when the pointer is
referred. It's better to save the variable returned from `CString::new()`
and use its pointer (in the same scope of the variable) when we need.

Run `cargo clippy` with `CString::new(text).unwrap().as_ptr()` will 
lead to a `temporary_cstring_as_ptr` error. Here is a [playground test](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=a45431ff7366612aa266b69cfbd3d308).

r? @kinetiknz 

