### PR TITLE
client: Handle shmem setup error gracefully.

### DIFF
--- a/client/src/stream.rs
+++ b/client/src/stream.rs
@@ -183,14 +183,26 @@ impl<'ctx> ClientStream<'ctx> {
 
         let input_file = unsafe { data.platform_handles[1].into_file() };
         let input_shm = if has_input {
-            Some(SharedMemSlice::from(&input_file, audioipc::SHM_AREA_SIZE).unwrap())
+            match SharedMemSlice::from(&input_file, audioipc::SHM_AREA_SIZE) {
+                Ok(shm) => Some(shm),
+                Err(e) => {
+                    debug!("Client failed to set up input shmem: {}", e);
+                    return Err(Error::error());
+                }
+            }
         } else {
             None
         };
 
         let output_file = unsafe { data.platform_handles[2].into_file() };
         let output_shm = if has_output {
-            Some(SharedMemMutSlice::from(&output_file, audioipc::SHM_AREA_SIZE).unwrap())
+            match SharedMemMutSlice::from(&output_file, audioipc::SHM_AREA_SIZE) {
+                Ok(shm) => Some(shm),
+                Err(e) => {
+                    debug!("Client failed to set up output shmem: {}", e);
+                    return Err(Error::error());
+                }
+            }
         } else {
             None
         };


### PR DESCRIPTION
This could fail due to low available address space (for example), so unwrapping the Result is inappropriate.

This is intended to be a fix for [BMO 1621360](https://bugzilla.mozilla.org/show_bug.cgi?id=1621360).

r? @ChunMinChang please