### PR TITLE
server: Re-init libcubeb rather than caching failure.

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -83,11 +83,18 @@ fn run() -> Result<ServerWrapper> {
         Err(e)
     })?;
 
-    let core_thread =
-        core::spawn_thread("AudioIPC Server RPC", move || Ok(()), || {}).or_else(|e| {
-            debug!("Failed to cubeb audio core event loop thread: {:?}", e);
-            Err(e)
-        })?;
+    let core_thread = core::spawn_thread(
+        "AudioIPC Server RPC",
+        move || {
+            audioipc::server_platform_init();
+            Ok(())
+        },
+        || {},
+    )
+    .or_else(|e| {
+        debug!("Failed to cubeb audio core event loop thread: {:?}", e);
+        Err(e)
+    })?;
 
     Ok(ServerWrapper {
         core_thread,


### PR DESCRIPTION
Re-attempt `cubeb_init` when a new client attaches, if the last initialization failed.

Addresses [BMO 1636722](https://bugzilla.mozilla.org/show_bug.cgi?id=1636722).

r? @ChunMinChang please