### PR TITLE
audioipc: Close process handle after use.

### DIFF
--- a/ipctest/src/main.rs
+++ b/ipctest/src/main.rs
@@ -133,6 +133,7 @@ fn run_client() -> Result<()> {
             FALSE,
             winnt::DUPLICATE_SAME_ACCESS,
         );
+        handleapi::CloseHandle(source);
         if ok == FALSE {
             bail!("DuplicateHandle failed");
         }


### PR DESCRIPTION
Unlike the pseudo-handle returned by [`GetCurrentProcess`](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess#remarks), the handle returned by [`OpenProcess`](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocess#remarks) must be closed after use.

Addresses [BMO 1644522](https://bugzilla.mozilla.org/show_bug.cgi?id=1644522).

r? @ChunMinChang please