### PR TITLE
Split stream initialization into two phases.

### DIFF
--- a/audioipc/src/fd_passing.rs
+++ b/audioipc/src/fd_passing.rs
@@ -8,7 +8,7 @@ use crate::cmsg;
 use crate::codec::Codec;
 use crate::messages::AssocRawPlatformHandle;
 use bytes::{Bytes, BytesMut, IntoBuf};
-use futures::{AsyncSink, Poll, Sink, StartSend, Stream, task};
+use futures::{task, AsyncSink, Poll, Sink, StartSend, Stream};
 use std::collections::VecDeque;
 use std::os::unix::io::RawFd;
 use std::{fmt, io, mem};

--- a/audioipc/src/frame.rs
+++ b/audioipc/src/frame.rs
@@ -5,7 +5,7 @@
 
 use crate::codec::Codec;
 use bytes::{Buf, Bytes, BytesMut, IntoBuf};
-use futures::{AsyncSink, Poll, Sink, StartSend, Stream, task};
+use futures::{task, AsyncSink, Poll, Sink, StartSend, Stream};
 use std::io;
 use tokio_io::{AsyncRead, AsyncWrite};
 

--- a/audioipc/src/handle_passing.rs
+++ b/audioipc/src/handle_passing.rs
@@ -6,7 +6,7 @@
 use crate::codec::Codec;
 use crate::messages::AssocRawPlatformHandle;
 use bytes::{Bytes, BytesMut, IntoBuf};
-use futures::{AsyncSink, Poll, Sink, StartSend, Stream, task};
+use futures::{task, AsyncSink, Poll, Sink, StartSend, Stream};
 use std::collections::VecDeque;
 use std::{fmt, io};
 use tokio_io::{AsyncRead, AsyncWrite};

--- a/audioipc/src/messages.rs
+++ b/audioipc/src/messages.rs
@@ -138,6 +138,12 @@ impl<'a> From<&'a cubeb::StreamParamsRef> for StreamParams {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct StreamCreateParams {
+    pub input_stream_params: Option<StreamParams>,
+    pub output_stream_params: Option<StreamParams>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct StreamInitParams {
     pub stream_name: Option<Vec<u8>>,
     pub input_device: usize,
@@ -198,7 +204,8 @@ pub enum ServerMessage {
     ContextSetupDeviceCollectionCallback,
     ContextRegisterDeviceCollectionChanged(ffi::cubeb_device_type, bool),
 
-    StreamInit(StreamInitParams),
+    StreamCreate(StreamCreateParams),
+    StreamInit(usize, StreamInitParams),
     StreamDestroy(usize),
 
     StreamStart(usize),
@@ -232,6 +239,7 @@ pub enum ClientMessage {
     ContextRegisteredDeviceCollectionChanged,
 
     StreamCreated(StreamCreate),
+    StreamInitialized,
     StreamDestroyed,
 
     StreamStarted,

--- a/client/src/stream.rs
+++ b/client/src/stream.rs
@@ -5,11 +5,11 @@
 
 use crate::ClientContext;
 use crate::{assert_not_in_callback, run_in_callback};
-use audioipc::codec::LengthDelimitedCodec;
 use audioipc::frame::{framed, Framed};
 use audioipc::messages::{self, CallbackReq, CallbackResp, ClientMessage, ServerMessage};
 use audioipc::rpc;
 use audioipc::shm::{SharedMemMutSlice, SharedMemSlice};
+use audioipc::{codec::LengthDelimitedCodec, messages::StreamCreateParams};
 use cubeb_backend::{ffi, DeviceRef, Error, Result, Stream, StreamOps};
 use futures::Future;
 use futures_cpupool::{CpuFuture, CpuPool};
@@ -167,16 +167,20 @@ impl<'ctx> ClientStream<'ctx> {
     ) -> Result<Stream> {
         assert_not_in_callback();
 
-        let has_input = init_params.input_stream_params.is_some();
-        let has_output = init_params.output_stream_params.is_some();
-
         let rpc = ctx.rpc();
-        let data = send_recv!(rpc, StreamInit(init_params) => StreamCreated())?;
+        let create_params = StreamCreateParams {
+            input_stream_params: init_params.input_stream_params,
+            output_stream_params: init_params.output_stream_params,
+        };
+        let data = send_recv!(rpc, StreamCreate(create_params) => StreamCreated())?;
 
         debug!(
             "token = {}, handles = {:?}",
             data.token, data.platform_handles
         );
+
+        let has_input = init_params.input_stream_params.is_some();
+        let has_output = init_params.output_stream_params.is_some();
 
         let stream =
             unsafe { audioipc::MessageStream::from_raw_fd(data.platform_handles[0].into_raw()) };
@@ -236,6 +240,8 @@ impl<'ctx> ClientStream<'ctx> {
             }))
             .expect("Failed to spawn CallbackServer");
         wait_rx.recv().unwrap();
+
+        send_recv!(rpc, StreamInit(data.token, init_params) => StreamInitialized)?;
 
         let stream = Box::into_raw(Box::new(ClientStream {
             context: ctx,


### PR DESCRIPTION
Split StreamCreate into StreamCreate and StreamInit.  StreamCreate performs
the pre-libcubeb IPC setup and StreamInit completes the libcubeb stream
initialization.  This avoids a circular dependency where a server-side
StreamInit needed to send messages back to the client before the client
could progress far enough to receive and process them.

Fix for [BMO 1661398](https://bugzilla.mozilla.org/show_bug.cgi?id=1661398).

r? @ChunMinChang please